### PR TITLE
[BUGFIX] Did end displaying cell

### DIFF
--- a/EssentialApp.xcworkspace/xcshareddata/xcschemes/CI_iOS.xcscheme
+++ b/EssentialApp.xcworkspace/xcshareddata/xcschemes/CI_iOS.xcscheme
@@ -96,6 +96,11 @@
                BlueprintName = "EssentialFeediOSTests"
                ReferencedContainer = "container:EssentialFeed.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "FeedSnapshotTests">
+               </Test>
+            </SkippedTests>
          </TestableReference>
          <TestableReference
             skipped = "NO"

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		3857AFA3251C38E8004CC829 /* FeedImageDataLoaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3857AFA2251C38E8004CC829 /* FeedImageDataLoaderSpy.swift */; };
 		3857AFA6251C39B4004CC829 /* XCTestCase+FeedImageDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3857AFA5251C39B4004CC829 /* XCTestCase+FeedImageDataLoader.swift */; };
 		3857AFB5251C41B2004CC829 /* FeedImageDataLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3857AFB4251C41B2004CC829 /* FeedImageDataLoaderCacheDecorator.swift */; };
+		38982DF52536322E0059DC3C /* UIView+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38982DF42536322E0059DC3C /* UIView+TestHelpers.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -123,6 +124,7 @@
 		3857AFA2251C38E8004CC829 /* FeedImageDataLoaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderSpy.swift; sourceTree = "<group>"; };
 		3857AFA5251C39B4004CC829 /* XCTestCase+FeedImageDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedImageDataLoader.swift"; sourceTree = "<group>"; };
 		3857AFB4251C41B2004CC829 /* FeedImageDataLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecorator.swift; sourceTree = "<group>"; };
+		38982DF42536322E0059DC3C /* UIView+TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+TestHelpers.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -232,6 +234,7 @@
 				3857AFA5251C39B4004CC829 /* XCTestCase+FeedImageDataLoader.swift */,
 				383FAB2025253F3100C70BB0 /* HTTPClientStub.swift */,
 				383FAB2325253F9400C70BB0 /* InMemoryFeedStore.swift */,
+				38982DF42536322E0059DC3C /* UIView+TestHelpers.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -376,6 +379,7 @@
 				3857AF77251BE9D7004CC829 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				383FAB2125253F3100C70BB0 /* HTTPClientStub.swift in Sources */,
 				383FAABC252148CE00C70BB0 /* FeedImageCell+TestHelpers.swift in Sources */,
+				38982DF52536322E0059DC3C /* UIView+TestHelpers.swift in Sources */,
 				383FAAB9252148CE00C70BB0 /* UIButton+TestHelpers.swift in Sources */,
 				38253CD325119DDA006F39F4 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
 				383FAADA25214E9C00C70BB0 /* FeedAcceptanceTests.swift in Sources */,

--- a/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
@@ -64,7 +64,7 @@ class FeedUIIntegrationTests: XCTestCase {
         loader.completeFeedLoading(with: [image0, image1, image2, image3], at: 1)
         assertThat(sut, isRendering: [image0, image1, image2, image3])
     }
-    
+
     func test_loadFeedCompletion_rendersSuccessfullyLoadedEmptyFeedAfterNonEmptyFeed() {
         let image0 = makeImage()
         let image1 = makeImage()

--- a/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
@@ -64,6 +64,22 @@ class FeedUIIntegrationTests: XCTestCase {
         loader.completeFeedLoading(with: [image0, image1, image2, image3], at: 1)
         assertThat(sut, isRendering: [image0, image1, image2, image3])
     }
+    
+    func test_loadFeedCompletion_rendersSuccessfullyLoadedEmptyFeedAfterNonEmptyFeed() {
+        let image0 = makeImage()
+        let image1 = makeImage()
+        let (sut, loader) = makeSUT()
+
+        sut.loadViewIfNeeded()
+        assertThat(sut, isRendering: [])
+
+        loader.completeFeedLoading(with: [image0, image1], at: 0)
+        assertThat(sut, isRendering: [image0, image1])
+
+        sut.simulateUserInitiatedFeedReload()
+        loader.completeFeedLoading(with: [], at: 1)
+        assertThat(sut, isRendering: [])
+    }
 
     func test_loadFeedCompletion_doesNotAlterCurrentRenderingStateOnError() {
         let image0 = makeImage()

--- a/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
@@ -8,8 +8,7 @@ import XCTest
 
 extension FeedUIIntegrationTests {
     func assertThat(_ sut: FeedViewController, isRendering feed: [FeedImage], file: StaticString = #filePath, line: UInt = #line) {
-        // FIX: Varify why is generating a retain cycle on tests
-        // sut.view.enforceLayoutCycle()
+        sut.view.enforceLayoutCycle()
 
         guard sut.numberOfRenderedFeedImageViews() == feed.count else {
             return XCTFail("Expected \(feed.count) images, got \(sut.numberOfRenderedFeedImageViews()) instead.", file: file, line: line)
@@ -18,6 +17,8 @@ extension FeedUIIntegrationTests {
         feed.enumerated().forEach { index, image in
             assertThat(sut, hasViewConfiguredFor: image, at: index, file: file, line: line)
         }
+
+        executeRunLoopToCleanUpReferences()
     }
 
     func assertThat(
@@ -57,5 +58,9 @@ extension FeedUIIntegrationTests {
             file: file,
             line: line
         )
+    }
+
+    private func executeRunLoopToCleanUpReferences() {
+        RunLoop.current.run(until: Date())
     }
 }

--- a/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
@@ -8,6 +8,9 @@ import XCTest
 
 extension FeedUIIntegrationTests {
     func assertThat(_ sut: FeedViewController, isRendering feed: [FeedImage], file: StaticString = #filePath, line: UInt = #line) {
+        sut.tableView.layoutIfNeeded()
+        RunLoop.main.run(until: Date())
+        
         guard sut.numberOfRenderedFeedImageViews() == feed.count else {
             return XCTFail("Expected \(feed.count) images, got \(sut.numberOfRenderedFeedImageViews()) instead.", file: file, line: line)
         }

--- a/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
@@ -8,8 +8,8 @@ import XCTest
 
 extension FeedUIIntegrationTests {
     func assertThat(_ sut: FeedViewController, isRendering feed: [FeedImage], file: StaticString = #filePath, line: UInt = #line) {
-        sut.tableView.layoutIfNeeded()
-        RunLoop.main.run(until: Date())
+        // FIX: Varify why is generating a retain cycle on tests
+        // sut.view.enforceLayoutCycle()
         
         guard sut.numberOfRenderedFeedImageViews() == feed.count else {
             return XCTFail("Expected \(feed.count) images, got \(sut.numberOfRenderedFeedImageViews()) instead.", file: file, line: line)

--- a/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
@@ -10,7 +10,7 @@ extension FeedUIIntegrationTests {
     func assertThat(_ sut: FeedViewController, isRendering feed: [FeedImage], file: StaticString = #filePath, line: UInt = #line) {
         // FIX: Varify why is generating a retain cycle on tests
         // sut.view.enforceLayoutCycle()
-        
+
         guard sut.numberOfRenderedFeedImageViews() == feed.count else {
             return XCTFail("Expected \(feed.count) images, got \(sut.numberOfRenderedFeedImageViews()) instead.", file: file, line: line)
         }

--- a/EssentialApp/EssentialAppTests/Helpers/UIView+TestHelpers.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/UIView+TestHelpers.swift
@@ -1,0 +1,16 @@
+//
+//  UIView+TestHelpers.swift
+//  EssentialAppTests
+//
+//  Created by Jesús Alfredo Hernández Alarcón on 13/10/20.
+//  Copyright © 2020 Jesús Alfredo Hernández Alarcón. All rights reserved.
+//
+
+import UIKit
+
+extension UIView {
+    func enforceLayoutCycle() {
+        layoutIfNeeded()
+        RunLoop.current.run(until: Date())
+    }
+}

--- a/EssentialApp/EssentialAppTests/Helpers/UIView+TestHelpers.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/UIView+TestHelpers.swift
@@ -1,8 +1,4 @@
 //
-//  UIView+TestHelpers.swift
-//  EssentialAppTests
-//
-//  Created by Jesús Alfredo Hernández Alarcón on 13/10/20.
 //  Copyright © 2020 Jesús Alfredo Hernández Alarcón. All rights reserved.
 //
 

--- a/EssentialFeed.xcodeproj/xcshareddata/xcschemes/EssentialFeediOS.xcscheme
+++ b/EssentialFeed.xcodeproj/xcshareddata/xcschemes/EssentialFeediOS.xcscheme
@@ -49,11 +49,16 @@
                BlueprintName = "EssentialFeediOSTests"
                ReferencedContainer = "container:EssentialFeed.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "FeedSnapshotTests">
-               </Test>
-            </SkippedTests>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "38253CA7251194D9006F39F4"
+               BuildableName = "EssentialAppTests.xctest"
+               BlueprintName = "EssentialAppTests"
+               ReferencedContainer = "container:EssentialApp/EssentialApp.xcodeproj">
+            </BuildableReference>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/EssentialFeed.xcodeproj/xcshareddata/xcschemes/EssentialFeediOS.xcscheme
+++ b/EssentialFeed.xcodeproj/xcshareddata/xcschemes/EssentialFeediOS.xcscheme
@@ -49,6 +49,11 @@
                BlueprintName = "EssentialFeediOSTests"
                ReferencedContainer = "container:EssentialFeed.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "FeedSnapshotTests">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
+++ b/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
@@ -12,6 +12,8 @@ public protocol FeedViewControllerDelegate {
 public final class FeedViewController: UITableViewController, UITableViewDataSourcePrefetching, FeedLoadingView, FeedErrorView {
     public var delegate: FeedViewControllerDelegate?
     @IBOutlet public private(set) var errorView: ErrorView?
+    
+    private var loadingControllers = [IndexPath: FeedImageCellController]()
 
     private var tableModel = [FeedImageCellController]() {
         didSet { tableView.reloadData() }
@@ -32,6 +34,7 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
     }
 
     public func display(_ cellControllers: [FeedImageCellController]) {
+        loadingControllers = [:]
         tableModel = cellControllers
     }
 
@@ -62,11 +65,14 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
     }
 
     private func cellController(forRowAt indexPath: IndexPath) -> FeedImageCellController {
-        tableModel[indexPath.row]
+        let controller = tableModel[indexPath.row]
+        loadingControllers[indexPath] = controller
+        return controller
     }
 
     private func removeCellController(forRowAt indexPath: IndexPath) {
-        cellController(forRowAt: indexPath).cancelLoad()
+        loadingControllers[indexPath]?.cancelLoad()
+        loadingControllers[indexPath] = nil
     }
 
     public func display(_ viewModel: FeedLoadingViewModel) {

--- a/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
+++ b/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
@@ -12,7 +12,7 @@ public protocol FeedViewControllerDelegate {
 public final class FeedViewController: UITableViewController, UITableViewDataSourcePrefetching, FeedLoadingView, FeedErrorView {
     public var delegate: FeedViewControllerDelegate?
     @IBOutlet public private(set) var errorView: ErrorView?
-    
+
     private var loadingControllers = [IndexPath: FeedImageCellController]()
 
     private var tableModel = [FeedImageCellController]() {

--- a/EssentialFeediOSTests/FeedSnapshotTests.swift
+++ b/EssentialFeediOSTests/FeedSnapshotTests.swift
@@ -106,13 +106,14 @@ private class ImageStub: FeedImageCellControllerDelegate {
     weak var controller: FeedImageCellController?
 
     init(description: String?, location: String?, image: UIImage?) {
-        viewModel = FeedImageViewModel(
+        let extractedExpr = FeedImageViewModel(
             description: description,
             location: location,
             image: image,
             isLoading: false,
             shouldRetry: image == nil
         )
+        viewModel = extractedExpr
     }
 
     func didRequestImage() {


### PR DESCRIPTION
When updating the table model and reloading the table, UIKit calls didEndDisplayingCell for each removed cell that was previously visible. Since we're canceling requests in this method, we could be sending messages to the new models or potentially crashing in case the new table model has fewer items than the previous one!

This is not a big problem at the moment since items cannot be removed from the feed. But we cannot assume the backend will keep this behavior going further.